### PR TITLE
WIP: Allow a configurable directory instead of using package layout

### DIFF
--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -62,9 +62,16 @@ def __main(draft, directory, project_version, project_date):
         ("misc", {"name": "Misc", "showcontent": False}),
     ])
 
+    if config.get("directory"):
+        base_directory = os.path.abspath(config["directory"])
+        fragment_directory = None
+    else:
+        base_directory = os.path.join(
+            directory, config['package_dir'], config['package'])
+        fragment_directory = "newsfragments"
+
     fragments = find_fragments(
-        os.path.join(directory, config['package_dir'], config['package']),
-        config['sections'])
+        base_directory, config['sections'], fragment_directory)
 
     click.echo("Rendering news fragments...")
 
@@ -103,8 +110,8 @@ def __main(draft, directory, project_version, project_date):
         stage_newsfile(directory, config['filename'])
 
         click.echo("Removing news fragments...")
-        remove_files(directory, config['package_dir'],
-                     config['package'], config['sections'], fragments)
+        remove_files(
+            base_directory, fragment_directory, config['sections'], fragments)
 
         click.echo("Done!")
 

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -30,7 +30,7 @@ def normalise(text):
     return text
 
 
-def find_fragments(base_directory, sections):
+def find_fragments(base_directory, sections, fragment_directory):
     """
     Sections are a dictonary of section names to paths.
     """
@@ -38,7 +38,11 @@ def find_fragments(base_directory, sections):
 
     for key, val in sections.items():
 
-        section_dir = os.path.join(base_directory, val, "newsfragments")
+        if fragment_directory is not None:
+            section_dir = os.path.join(base_directory, val, fragment_directory)
+        else:
+            section_dir = os.path.join(base_directory, val)
+
         files = os.listdir(section_dir)
 
         file_content = {}

--- a/src/towncrier/_git.py
+++ b/src/towncrier/_git.py
@@ -7,16 +7,16 @@ import os
 import click
 
 
-def remove_files(directory, package_dir, package, sections, fragments):
-
-    base_dir = os.path.join(directory, package_dir, package)
-
+def remove_files(base_dir, fragment_directory, sections, fragments):
     to_remove = []
 
     for section_name, categories in fragments.items():
 
-        section_dir = os.path.join(base_dir, "newsfragments",
-                                   sections[section_name])
+        if fragment_directory is not None:
+            section_dir = os.path.join(base_dir, fragment_directory,
+                                       sections[section_name])
+        else:
+            section_dir = os.path.join(base_dir, sections[section_name])
 
         for category_name, category_items in categories.items():
 

--- a/src/towncrier/_settings.py
+++ b/src/towncrier/_settings.py
@@ -14,7 +14,8 @@ def load_config(from_dir):
     config = configparser.ConfigParser(
         {
             'package_dir': '.',
-            'filename': 'NEWS.rst'
+            'filename': 'NEWS.rst',
+            'directory': None,
         }
     )
     config.read(os.path.join(from_dir, "towncrier.ini"))
@@ -30,5 +31,6 @@ def load_config(from_dir):
         'package': config.get('towncrier', 'package'),
         'package_dir': config.get('towncrier', 'package_dir'),
         'filename': config.get('towncrier', 'filename'),
+        'directory': config.get('towncrier', 'directory'),
         'sections': {'': ''},
     }


### PR DESCRIPTION
Instead of ``<package>/<section>/<newsfragments>`` being the only real option, this allows instead to define your own top level news fragment directory. This could be something like ``./news`` and then inside of that directory there is either news fragments directly, or sub directories for different sections.


Fixes #24