### PR TITLE
Ignore extensions on fragment filenames

### DIFF
--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -71,7 +71,7 @@ def split_fragments(fragments, definitions):
             if len(parts) == 1:
                 continue
             else:
-                ticket, category = parts
+                ticket, category = parts[:2]
 
             if category not in definitions:
                 continue

--- a/src/towncrier/newsfragments/62.feature
+++ b/src/towncrier/newsfragments/62.feature
@@ -1,0 +1,1 @@
+You can now name newsfragments like 123.feature.rst, or 123.feature.txt, or 123.feature.whatever.you.want, and towncrier will ignore the extension.

--- a/src/towncrier/test/test_cli.py
+++ b/src/towncrier/test/test_cli.py
@@ -56,6 +56,9 @@ class TestCli(TestCase):
             os.mkdir('foo/newsfragments')
             with open('foo/newsfragments/123.feature', 'w') as f:
                 f.write('Adds levitation')
+            # Towncrier ignores .rst extension
+            with open('foo/newsfragments/124.feature.rst', 'w') as f:
+                f.write('Extends levitation')
 
             result = runner.invoke(_main, ['--draft', '--date', '01-01-2001'])
 
@@ -66,5 +69,6 @@ class TestCli(TestCase):
             u'fragments...\nDraft only -- nothing has been written.\nWhat is '
             u'seen below is what would be written.\n\nFoo 1.2.3 (01-01-2001)'
             u'\n======================\n'
-            u'\n\nFeatures\n--------\n\n- Adds levitation (#123)\n\n'
+            u'\n\nFeatures\n--------\n\n- Adds levitation (#123)\n'
+            u'- Extends levitation (#124)\n\n'
         )


### PR DESCRIPTION
Now you can name fragments like 123.feature.rst, to make your editor
happy.

Fixes gh-62.