### PR TITLE
Add issue_format= configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
     package = "towncrier"
     package_dir = "src"
     filename = "NEWS.rst"
+    issue_format = "`#{issue} <https://https://github.com/hawkowl/towncrier/issues/{issue}>`__"
 
     [[tool.towncrier.section]]
         path = ""

--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -71,7 +71,8 @@ def __main(draft, directory, project_version, project_date):
     click.echo("Rendering news fragments...", err=to_err)
 
     fragments = split_fragments(fragments, definitions)
-    rendered = render_fragments(template, fragments, definitions)
+    rendered = render_fragments(
+        template, config['issue_format'], fragments, definitions)
 
     if not project_version:
         project_version = get_version(

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -93,7 +93,36 @@ def split_fragments(fragments, definitions):
     return output
 
 
-def render_fragments(template, fragments, definitions, major=u"-", minor=u"~"):
+def issue_key(issue):
+    # We want integer issues to sort as integers, and we also want string
+    # issues to sort as strings. We arbitrarily put string issues before
+    # integer issues (hopefully no-one uses both at once).
+    try:
+        return (int(issue), u"")
+    except Exception:
+        # Maybe we should sniff strings like "gh-10" -> (10, "gh-10")?
+        return (-1, issue)
+
+
+def entry_key(entry):
+    _, issues = entry
+    return [issue_key(issue) for issue in issues]
+
+
+def render_issue(issue_format, issue):
+    if issue_format is None:
+        try:
+            int(issue)
+            return u"#" + issue
+        except Exception:
+            return issue
+    else:
+        return issue_format.format(issue=issue)
+
+
+def render_fragments(
+        template, issue_format, fragments, definitions, major=u"-", minor=u"~"
+):
     """
     Render the fragments into a news file.
     """
@@ -107,19 +136,31 @@ def render_fragments(template, fragments, definitions, major=u"-", minor=u"~"):
         data[section_name] = {}
 
         for category_name, category_value in section_value.items():
+            # Suppose we start with an ordering like this:
+            #
+            # - Fix the thing (#7, #123, #2)
+            # - Fix the other thing (#1)
+
+            # First we sort the issues inside each line:
+            #
+            # - Fix the thing (#2, #7, #123)
+            # - Fix the other thing (#1)
+            entries = []
+            for text, issues in category_value.items():
+                entries.append((text, sorted(issues, key=issue_key)))
+
+            # Then we sort the lines:
+            #
+            # - Fix the other thing (#1)
+            # - Fix the thing (#2, #7, #123)
+            entries.sort(key=entry_key)
+
+            # Then we put these nicely sorted entries back in an ordered dict
+            # for the template, after formatting each issue number
             categories = OrderedDict()
-
-            for text, tickets in category_value.items():
-                ticket_numbers = []
-
-                for ticket in tickets:
-                    try:
-                        int(ticket)
-                        ticket_numbers.append(u"#" + ticket)
-                    except:
-                        ticket_numbers.append(ticket)
-
-                categories[text] = ticket_numbers
+            for text, issues in entries:
+                rendered = [render_issue(issue_format, i) for i in issues]
+                categories[text] = rendered
 
             data[section_name][category_name] = categories
 

--- a/src/towncrier/_settings.py
+++ b/src/towncrier/_settings.py
@@ -54,6 +54,11 @@ def load_config_ini(from_dir):
         title_format = _title_format
 
     try:
+        issue_format = config.get('towncrier', 'issue_format')
+    except configparser.NoOptionError:
+        issue_format = None
+
+    try:
         template_fname = config.get('towncrier', 'template')
     except configparser.NoOptionError:
         template_fname = None
@@ -68,6 +73,7 @@ def load_config_ini(from_dir):
         'template': template_fname,
         'start_line': start_string,
         'title_format': title_format,
+        'issue_format': issue_format,
     }
 
 
@@ -113,6 +119,7 @@ def load_config_toml(from_dir):
         'template': config.get('template', _template_fname),
         'start_line': config.get('start_string', _start_string),
         'title_format': config.get('title_format', _title_format),
+        'issue_format': config.get('issue_format'),
     }
 
 

--- a/src/towncrier/newsfragments/52.feature
+++ b/src/towncrier/newsfragments/52.feature
@@ -1,0 +1,1 @@
+Added new option ``issue_format``. For example, this can be used to make issue text in the NEWS file be formatted as ReST links to the issue tracker.

--- a/src/towncrier/templates/template.rst
+++ b/src/towncrier/templates/template.rst
@@ -10,12 +10,12 @@
 {{ underline * definitions[category]['name']|length }}
 
 {% if definitions[category]['showcontent'] %}
-{% for text, values in sections[section][category]|dictsort(by='value') %}
-- {{ text }} ({{ values|sort|join(', ') }})
+{% for text, values in sections[section][category].items() %}
+- {{ text }} ({{ values|join(', ') }})
 {% endfor %}
 
 {% else %}
-- {{ sections[section][category]['']|sort|join(', ') }}
+- {{ sections[section][category]['']|join(', ') }}
 
 {% endif %}
 {% if sections[section][category]|length == 0 %}

--- a/src/towncrier/test/test_cli.py
+++ b/src/towncrier/test/test_cli.py
@@ -2,10 +2,24 @@
 # See LICENSE for details.
 
 import os
+from contextlib import contextmanager
 from twisted.trial.unittest import TestCase
 
 from click.testing import CliRunner
 from .. import _main
+
+
+@contextmanager
+def setup_simple_project():
+    with open('pyproject.toml', 'w') as f:
+        f.write(
+            '[tool.towncrier]\n'
+            'package = "foo"\n'
+        )
+    os.mkdir('foo')
+    with open('foo/__init__.py', 'w') as f:
+        f.write('__version__ = "1.2.3"\n')
+    os.mkdir('foo/newsfragments')
 
 
 class TestCli(TestCase):
@@ -58,6 +72,28 @@ class TestCli(TestCase):
                 f.write('Adds levitation')
 
             result = runner.invoke(_main, ['--draft', '--date', '01-01-2001'])
+
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual(
+            result.output,
+            u'Loading template...\nFinding news fragments...\nRendering news '
+            u'fragments...\nDraft only -- nothing has been written.\nWhat is '
+            u'seen below is what would be written.\n\nFoo 1.2.3 (01-01-2001)'
+            u'\n======================\n'
+            u'\n\nFeatures\n--------\n\n- Adds levitation (#123)\n\n'
+        )
+
+    def test_sorting(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            setup_simple_project()
+            with open('foo/newsfragments/123.feature', 'w') as f:
+                f.write('Adds levitation')
+
+            result = runner.invoke(_main, ['--draft', '--date', '01-01-2001'])
+
+        # Issues should be sorted alphabetic before
 
         self.assertEqual(0, result.exit_code)
         self.assertEqual(

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -86,7 +86,8 @@ Old text.
                            "NEWS.rst",
                            ".. towncrier release notes start\n",
                            "MyProject 1.0\n=============\n",
-                           render_fragments(template, fragments, definitions))
+                           render_fragments(
+                               template, None, fragments, definitions))
 
         with open(os.path.join(tempdir, "NEWS.rst"), "r") as f:
             output = f.read()
@@ -181,7 +182,8 @@ Old text.
                            "NEWS.rst",
                            ".. towncrier release notes start\n",
                            "MyProject 1.0\n=============\n",
-                           render_fragments(template, fragments, definitions))
+                           render_fragments(
+                               template, None, fragments, definitions))
 
         with open(os.path.join(tempdir, "NEWS.rst"), "r") as f:
             output = f.read()


### PR DESCRIPTION
By default you still get '#foo' for integers, and 'foo' for
non-integers, but you can also define a format string to generate, for
example, a link to the issue tracker.

Also:

- Redo sorting in a more rational way, based on sorting values instead
  of rendered text.

- Add issue_format= to towncrier's own pyproject.toml