### PR TITLE
Add help entry for --version

### DIFF
--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -31,7 +31,7 @@ def _get_date():
                     "don't check versions."))
 @click.option('--dir', 'directory', default='.')
 @click.option('--version', 'project_version', default=None,
-              help="Force news to be rendered with exactly this version.")
+              help="Render the news fragments using given version.")
 @click.option('--date', 'project_date', default=None)
 @click.option('--yes', 'answer_yes', default=False, flag_value=True,
               help="Do not ask for confirmation to remove news fragments.")

--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -30,7 +30,8 @@ def _get_date():
               help=("Render the news fragments, don't write to files, "
                     "don't check versions."))
 @click.option('--dir', 'directory', default='.')
-@click.option('--version', 'project_version', default=None)
+@click.option('--version', 'project_version', default=None,
+              help="Force news to be rendered with exactly this version.")
 @click.option('--date', 'project_date', default=None)
 @click.option('--yes', 'answer_yes', default=False, flag_value=True,
               help="Do not ask for confirmation to remove news fragments.")


### PR DESCRIPTION
I was wondering if this is possible but did not see the option with `towncrier --help`. I tried it anyway, saw that it works and came here to tell the world about it :)