### PR TITLE
A more generic way to render ids from file names (e.g. issues)

### DIFF
--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -73,10 +73,10 @@ def __main(draft, directory, project_version, project_date, answer_yes):
     click.echo("Rendering news fragments...", err=to_err)
 
     fragments = split_fragments(fragments, definitions)
+    formats = config['formats']
     rendered = render_fragments(
         # The 0th underline is used for the top line
-        template, config['issue_format'], fragments, definitions,
-        config['underlines'][1:])
+        template, formats, fragments, definitions, config['underlines'][1:])
 
     if not project_version:
         project_version = get_version(

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -93,7 +93,7 @@ def split_fragments(fragments, definitions):
     return output
 
 
-def issue_key(issue):
+def sorting_hat(issue):
     # We want integer issues to sort as integers, and we also want string
     # issues to sort as strings. We arbitrarily put string issues before
     # integer issues (hopefully no-one uses both at once).
@@ -106,23 +106,25 @@ def issue_key(issue):
 
 def entry_key(entry):
     _, issues = entry
-    return [issue_key(issue) for issue in issues]
+    return [sorting_hat(issue) for issue in issues]
 
 
-def render_issue(issue_format, issue):
-    if issue_format is None:
+# todo rename
+def render_issue(incoming, id_):
+    if not incoming:
         try:
-            int(issue)
-            return u"#" + issue
+            int(id_)
+            return u"#" + id_
         except Exception:
-            return issue
-    else:
-        return issue_format.format(issue=issue)
+            return id_
+    if not isinstance(incoming, list):
+        return incoming.format(id_=id_)
+    if incoming:
+        # TODO
+        return
 
 
-def render_fragments(
-        template, issue_format, fragments, definitions, underlines,
-):
+def render_fragments(template, formats, fragments, definitions, underlines):
     """
     Render the fragments into a news file.
     """
@@ -147,7 +149,7 @@ def render_fragments(
             # - Fix the other thing (#1)
             entries = []
             for text, issues in category_value.items():
-                entries.append((text, sorted(issues, key=issue_key)))
+                entries.append((text, sorted(issues, key=sorting_hat)))
 
             # Then we sort the lines:
             #
@@ -159,7 +161,7 @@ def render_fragments(
             # for the template, after formatting each issue number
             categories = OrderedDict()
             for text, issues in entries:
-                rendered = [render_issue(issue_format, i) for i in issues]
+                rendered = [render_issue(formats, i) for i in issues]
                 categories[text] = rendered
 
             data[section_name][category_name] = categories

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import, division, print_function
 
 import os
+import re
 import textwrap
 
 from collections import OrderedDict
@@ -117,11 +118,11 @@ def render_issue(incoming, id_):
             return u"#" + id_
         except Exception:
             return id_
-    if not isinstance(incoming, list):
-        return incoming.format(id_=id_)
-    if incoming:
-        # TODO
-        return
+    for kind, payload in incoming.items():
+        for pattern in payload['patterns']:
+            match = re.match(pattern, id_)
+            if match:
+                return payload['format'].format(id=id_)
 
 
 def render_fragments(template, formats, fragments, definitions, underlines):

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -110,8 +110,7 @@ def entry_key(entry):
     return [sorting_hat(issue) for issue in issues]
 
 
-# todo rename
-def render_issue(incoming, id_):
+def render_from_formats(incoming, id_):
     if not incoming:
         try:
             int(id_)
@@ -162,7 +161,7 @@ def render_fragments(template, formats, fragments, definitions, underlines):
             # for the template, after formatting each issue number
             categories = OrderedDict()
             for text, issues in entries:
-                rendered = [render_issue(formats, i) for i in issues]
+                rendered = [render_from_formats(formats, i) for i in issues]
                 categories[text] = rendered
 
             data[section_name][category_name] = categories

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -111,17 +111,17 @@ def entry_key(entry):
 
 
 def render_from_formats(incoming, id_):
-    if not incoming:
-        try:
-            int(id_)
-            return u"#" + id_
-        except Exception:
-            return id_
-    for kind, payload in incoming.items():
-        for pattern in payload['patterns']:
-            match = re.match(pattern, id_)
-            if match:
-                return payload['format'].format(id=id_)
+    if incoming:
+        for kind, payload in incoming.items():
+            for pattern in payload['patterns']:
+                match = re.match(pattern, id_)
+                if match:
+                    return payload['format'].format(id=id_)
+    try:
+        int(id_)
+        return u"#" + id_
+    except Exception:
+        return id_
 
 
 def render_fragments(template, formats, fragments, definitions, underlines):

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -94,15 +94,15 @@ def split_fragments(fragments, definitions):
     return output
 
 
-def sorting_hat(issue):
+def sorting_hat(sortable):
     # We want integer issues to sort as integers, and we also want string
     # issues to sort as strings. We arbitrarily put string issues before
     # integer issues (hopefully no-one uses both at once).
     try:
-        return (int(issue), u"")
+        return (int(sortable), u"")
     except Exception:
         # Maybe we should sniff strings like "gh-10" -> (10, "gh-10")?
-        return (-1, issue)
+        return (-1, sortable)
 
 
 def entry_key(entry):

--- a/src/towncrier/_settings.py
+++ b/src/towncrier/_settings.py
@@ -38,20 +38,32 @@ def load_config(from_dir):
             "The [tool.towncrier] section has no required 'package' key.")
 
     sections = OrderedDict()
-    types = OrderedDict()
-
     if "section" in config:
         for x in config["section"]:
             sections[x.get('name', '')] = x['path']
     else:
         sections[''] = ''
 
+    types = OrderedDict()
     if "type" in config:
         for x in config["type"]:
-            types[x["directory"]] = {"name": x["name"],
-                                     "showcontent": x["showcontent"]}
+            types[x["directory"]] = {
+                "name": x["name"], "showcontent": x["showcontent"]}
     else:
         types = _default_types
+
+    formats = OrderedDict()
+    if "format" in config:
+        for x in config["format"]:
+            formats[x["kind"]] = {
+                "patterns": x["patterns"], "format": x["format"]}
+    else:
+        # backwards compatibility
+        issue_format = config.get('issue_format')
+        if issue_format:
+            issue_format = issue_format.replace('{issue}', '{id_}')
+            formats["old-issue-format"] = {
+                "patterns": [".*"], "format": issue_format}
 
     return {
         'package': config.get('package'),
@@ -63,6 +75,6 @@ def load_config(from_dir):
         'template': config.get('template', _template_fname),
         'start_line': config.get('start_string', _start_string),
         'title_format': config.get('title_format', _title_format),
-        'issue_format': config.get('issue_format'),
+        'formats': formats,
         'underlines': config.get('underlines', _underlines)
     }

--- a/src/towncrier/_settings.py
+++ b/src/towncrier/_settings.py
@@ -61,7 +61,7 @@ def load_config(from_dir):
         # backwards compatibility
         issue_format = config.get('issue_format')
         if issue_format:
-            issue_format = issue_format.replace('{issue}', '{id_}')
+            issue_format = issue_format.replace('{issue}', '{id}')
             formats["old-issue-format"] = {
                 "patterns": [".*"], "format": issue_format}
 

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -181,7 +181,7 @@ Bugfixes
             template, None, fragments, definitions, ["*", "^"])
         self.assertEqual(output, expected_output_weird_underlines)
 
-    def test_issue_format(self):
+    def test_old_issue_format(self):
         """
         issue_format option can be used to format issue text.
         And sorting happens before formatting, so numerical issues are still
@@ -216,7 +216,7 @@ Misc
 
         fragments = split_fragments(fragments, definitions)
         output = render_fragments(
-            template, u"xx{issue}", fragments, definitions, ["-", "~"])
+            template, u"xx{id_}", fragments, definitions, ["-", "~"])
         self.assertEqual(output, expected_output)
 
     def test_line_wrapping(self):

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -215,8 +215,10 @@ Misc
             "templates/template.rst").decode('utf8')
 
         fragments = split_fragments(fragments, definitions)
+        formats = {'old-issue-format':
+                       {'patterns': ['.*'], 'format': u"xx{id}"}}
         output = render_fragments(
-            template, u"xx{id_}", fragments, definitions, ["-", "~"])
+            template, formats, fragments, definitions, ["-", "~"])
         self.assertEqual(output, expected_output)
 
     def test_line_wrapping(self):

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -215,8 +215,7 @@ Misc
             "templates/template.rst").decode('utf8')
 
         fragments = split_fragments(fragments, definitions)
-        formats = {'old-issue-format':
-                       {'patterns': ['.*'], 'format': u"xx{id}"}}
+        formats = {'issue': {'patterns': ['.*'], 'format': u"xx{id}"}}
         output = render_fragments(
             template, formats, fragments, definitions, ["-", "~"])
         self.assertEqual(output, expected_output)


### PR DESCRIPTION
We added towncrier to [tox](https://github.com/tox-dev/tox) and needed a way to create links to pull requests - not just issues. I tried to implement that in a generic way and would be interested in feedback if this would be added to towncrier like this or in a different way.

for tox this looks like this now. Instead of having issue_format there are format sections that link regular expresions to their corresponding replacements.

```toml
[tool.towncrier]
    package = "tox"
    filename = "CHANGELOG.rst"
    directory = "tox/changelog"
    template = "tox/changelog/template.jinja2"
    title_format = "{version} ({project_date})"
    underlines = ["=", "-"]

    [[tool.towncrier.section]]
        path = ""

    [[tool.towncrier.format]]
        kind = "issue"
        patterns = ["issue(\\d)", "(\\d)"]
        format = "`#{id} <https://github.com/tox-dev/tox/issues/{id}>`_"

    [[tool.towncrier.format]]
        kind = "pull request"
        patterns = ["pr(\\d)", "pull-request(\\d)"]
        format = "`#{id} <https://github.com/tox-dev/tox/pull/{id}>`_"
```

The change is backwards compatible to the old way of doing stuff.

I did not add any specific tests or documentation yet, but will gladly do, if this would be merged.