### PR TITLE
Several fixes to newsfragment extension handling

### DIFF
--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -67,8 +67,8 @@ def __main(draft, directory, project_version, project_date, answer_yes):
             directory, config['package_dir'], config['package']))
         fragment_directory = "newsfragments"
 
-    fragments = find_fragments(
-        base_directory, config['sections'], fragment_directory)
+    fragments, fragment_filenames = find_fragments(
+        base_directory, config['sections'], fragment_directory, definitions)
 
     click.echo("Rendering news fragments...", err=to_err)
 
@@ -114,9 +114,7 @@ def __main(draft, directory, project_version, project_date, answer_yes):
         stage_newsfile(directory, config['filename'])
 
         click.echo("Removing news fragments...", err=to_err)
-        remove_files(
-            base_directory, fragment_directory, config['sections'],
-            fragments, answer_yes)
+        remove_files(fragment_filenames, answer_yes)
 
         click.echo("Done!", err=to_err)
 

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -78,6 +78,11 @@ def find_fragments(base_directory, sections, fragment_directory, definitions):
             fragment_filenames.append(full_filename)
             with open(full_filename, "rb") as f:
                 data = f.read().decode('utf8', 'replace')
+            if (ticket, category) in file_content:
+                raise ValueError(
+                    "multiple files for {}.{} in {}"
+                    .format(ticket, category, section_dir)
+                )
             file_content[ticket, category] = data
 
         content[key] = file_content

--- a/src/towncrier/_git.py
+++ b/src/towncrier/_git.py
@@ -7,29 +7,8 @@ import os
 import click
 
 
-def remove_files(base_dir, fragment_directory, sections, fragments,
-                 answer_yes):
-    to_remove = []
-
-    for section_name, categories in fragments.items():
-
-        if fragment_directory is not None:
-            section_dir = os.path.join(base_dir, sections[section_name],
-                                       fragment_directory)
-        else:
-            section_dir = os.path.join(base_dir, sections[section_name])
-
-        for category_name, category_items in categories.items():
-
-            for tickets in category_items.values():
-
-                for ticket in tickets:
-
-                    filename = str(ticket) + "." + category_name
-                    to_remove.append(os.path.join(
-                        section_dir, filename))
-
-    if not to_remove:
+def remove_files(fragment_filenames, answer_yes):
+    if not fragment_filenames:
         return
 
     if answer_yes:
@@ -37,12 +16,12 @@ def remove_files(base_dir, fragment_directory, sections, fragments,
     else:
         click.echo("I want to remove the following files:")
 
-    for filename in to_remove:
+    for filename in fragment_filenames:
         click.echo(filename)
 
     if answer_yes or click.confirm('Is it okay if I remove those files?',
                                    default=True):
-        call(["git", "rm", "--quiet"] + to_remove)
+        call(["git", "rm", "--quiet"] + fragment_filenames)
 
 
 def stage_newsfile(directory, filename):

--- a/src/towncrier/newsfragments/101.bugfix
+++ b/src/towncrier/newsfragments/101.bugfix
@@ -1,0 +1,1 @@
+If there are two newsfragments with the same name (example: "123.bugfix.rst" and "123.bugfix.rst~"), then raise an error instead of silently picking one at random.

--- a/src/towncrier/newsfragments/99.bugfix
+++ b/src/towncrier/newsfragments/99.bugfix
@@ -1,0 +1,1 @@
+When cleaning up old newsfragments, if a newsfragment is named "123.feature.rst", then remove that file instead of trying to remove the non-existent "123.feature".

--- a/src/towncrier/test/test_cli.py
+++ b/src/towncrier/test/test_cli.py
@@ -2,7 +2,6 @@
 # See LICENSE for details.
 import os
 from subprocess import call
-from contextlib import contextmanager
 from textwrap import dedent
 from twisted.trial.unittest import TestCase
 
@@ -10,7 +9,6 @@ from click.testing import CliRunner
 from .. import _main
 
 
-@contextmanager
 def setup_simple_project():
     with open('pyproject.toml', 'w') as f:
         f.write(
@@ -31,15 +29,7 @@ class TestCli(TestCase):
         runner = CliRunner()
 
         with runner.isolated_filesystem():
-            with open('pyproject.toml', 'w') as f:
-                f.write(
-                    '[tool.towncrier]\n'
-                    'package = "foo"\n'
-                )
-            os.mkdir('foo')
-            with open('foo/__init__.py', 'w') as f:
-                f.write('__version__ = "1.2.3"\n')
-            os.mkdir('foo/newsfragments')
+            setup_simple_project()
             with open('foo/newsfragments/123.feature', 'w') as f:
                 f.write('Adds levitation')
             # Towncrier ignores .rst extension
@@ -198,15 +188,7 @@ class TestCli(TestCase):
         runner = CliRunner()
 
         with runner.isolated_filesystem():
-            with open('pyproject.toml', 'w') as f:
-                f.write(
-                    '[tool.towncrier]\n'
-                    'package = "foo"\n'
-                )
-            os.mkdir('foo')
-            with open('foo/__init__.py', 'w') as f:
-                f.write('__version__ = "1.2.3"\n')
-            os.mkdir('foo/newsfragments')
+            setup_simple_project()
             fragment_path = 'foo/newsfragments/123.feature'
             with open(fragment_path, 'w') as f:
                 f.write('Adds levitation')

--- a/src/towncrier/test/test_cli.py
+++ b/src/towncrier/test/test_cli.py
@@ -49,6 +49,23 @@ class TestCli(TestCase):
             u'- Extends levitation (#124)\n\n'
         )
 
+    def test_collision(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            setup_simple_project()
+            # Note that both are 123.feature
+            with open('foo/newsfragments/123.feature', 'w') as f:
+                f.write('Adds levitation')
+            with open('foo/newsfragments/123.feature.rst', 'w') as f:
+                f.write('Extends levitation')
+
+            result = runner.invoke(_main, ['--draft', '--date', '01-01-2001'])
+
+        # This should fail
+        self.assertEqual(type(result.exception), ValueError)
+        self.assertIn("multiple files for 123.feature", str(result.exception))
+
     def test_section_and_type_sorting(self):
         """
         Sections and types should be output in the same order that they're

--- a/src/towncrier/test/test_cli.py
+++ b/src/towncrier/test/test_cli.py
@@ -32,9 +32,15 @@ class TestCli(TestCase):
             setup_simple_project()
             with open('foo/newsfragments/123.feature', 'w') as f:
                 f.write('Adds levitation')
-            # Towncrier ignores .rst extension
+            # Towncrier treats this as 124.feature, ignoring .rst extension
             with open('foo/newsfragments/124.feature.rst', 'w') as f:
                 f.write('Extends levitation')
+            # Towncrier ignores files that don't have a dot
+            with open('foo/newsfragments/README', 'w') as f:
+                f.write('Blah blah')
+            # And files that don't have a valid category
+            with open('foo/newsfragments/README.rst', 'w') as f:
+                f.write('**Blah blah**')
 
             result = runner.invoke(_main, ['--draft', '--date', '01-01-2001'])
 

--- a/src/towncrier/test/test_cli.py
+++ b/src/towncrier/test/test_cli.py
@@ -189,9 +189,12 @@ class TestCli(TestCase):
 
         with runner.isolated_filesystem():
             setup_simple_project()
-            fragment_path = 'foo/newsfragments/123.feature'
-            with open(fragment_path, 'w') as f:
+            fragment_path1 = 'foo/newsfragments/123.feature'
+            fragment_path2 = 'foo/newsfragments/124.feature.rst'
+            with open(fragment_path1, 'w') as f:
                 f.write('Adds levitation')
+            with open(fragment_path2, 'w') as f:
+                f.write('Extends levitation')
 
             call(["git", "init"])
             call(["git", "config", "user.name", "user"])
@@ -204,4 +207,5 @@ class TestCli(TestCase):
             self.assertEqual(0, result.exit_code)
             path = 'NEWS.rst'
             self.assertTrue(os.path.isfile(path))
-            self.assertFalse(os.path.isfile(fragment_path))
+            self.assertFalse(os.path.isfile(fragment_path1))
+            self.assertFalse(os.path.isfile(fragment_path2))

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -29,17 +29,15 @@ class FormatterTests(TestCase):
 
         fragments = {
             "": {
-                "1.misc": u"",
-                "baz.misc": u"",
-                "2.feature": u"Foo added.",
-                "421.feature~": u"Foo added.",
-                "5.feature": u"Foo added.    \n",
-                "6.bugfix": u"Foo added.",
-                "NEWS": u"Some junk.",
+                ("1", "misc"): u"",
+                ("baz", "misc"): u"",
+                ("2", "feature"): u"Foo added.",
+                ("5", "feature"): u"Foo added.    \n",
+                ("6", "bugfix"): u"Foo added.",
             },
             "Web": {
-                "3.bugfix": u"Web fixed.    ",
-                "4.feature": u"Foo added."
+                ("3", "bugfix"): u"Web fixed.    ",
+                ("4", "feature"): u"Foo added."
             }
         }
 
@@ -85,19 +83,19 @@ class FormatterTests(TestCase):
             ("", {
                 # asciibetical sorting will do 1, 142, 9
                 # we want 1, 9, 142 instead
-                "142.misc": u"",
-                "1.misc": u"",
-                "9.misc": u"",
-                "bar.misc": u"",
-                "4.feature": u"Stuff!",
-                "2.feature": u"Foo added.",
-                "72.feature": u"Foo added.",
-                "9.feature": u"Foo added.",
-                "baz.feature": u"Fun!",
+                ("142", "misc"): u"",
+                ("1", "misc"): u"",
+                ("9", "misc"): u"",
+                ("bar", "misc"): u"",
+                ("4", "feature"): u"Stuff!",
+                ("2", "feature"): u"Foo added.",
+                ("72", "feature"): u"Foo added.",
+                ("9", "feature"): u"Foo added.",
+                ("baz", "feature"): u"Fun!",
             }),
             ("Names", {}),
             ("Web", {
-                "3.bugfix": u"Web fixed.",
+                ("3", "bugfix"): u"Web fixed.",
             }),
         ])
 
@@ -192,10 +190,10 @@ Bugfixes
             "": {
                 # asciibetical sorting will do 1, 142, 9
                 # we want 1, 9, 142 instead
-                "142.misc": u"",
-                "1.misc": u"",
-                "9.misc": u"",
-                "bar.misc": u"",
+                ("142", "misc"): u"",
+                ("1", "misc"): u"",
+                ("9", "misc"): u"",
+                ("bar", "misc"): u"",
             }
         }
 
@@ -228,12 +226,12 @@ Misc
 
         fragments = {
             "": {
-                "1.feature": u"""
+                ("1", "feature"): u"""
                 asdf asdf asdf asdf looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong newsfragment.
                 """,  # NOQA
-                "2.feature": u"https://google.com/q=?" + u"-" * 100,
-                "3.feature": u"a " * 80,
-                "4.feature": u"""
+                ("2", "feature"): u"https://google.com/q=?" + u"-" * 100,
+                ("3", "feature"): u"a " * 80,
+                ("4", "feature"): u"""
                 w
 
                 h

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -18,15 +18,15 @@ class WritingTests(TestCase):
 
         fragments = OrderedDict([
             ("", {
-                "142.misc": u"",
-                "1.misc": u"",
-                "4.feature": u"Stuff!",
-                "2.feature": u"Foo added.",
-                "72.feature": u"Foo added.",
+                ("142", "misc"): u"",
+                ("1", "misc"): u"",
+                ("4", "feature"): u"Stuff!",
+                ("2", "feature"): u"Foo added.",
+                ("72", "feature"): u"Foo added.",
             }),
             ("Names", {}),
             ("Web", {
-                "3.bugfix": u"Web fixed.",
+                ("3", "bugfix"): u"Web fixed.",
             }),
         ])
 
@@ -102,16 +102,16 @@ Old text.
         """
         fragments = OrderedDict([
             ("", {
-                "142.misc": u"",
-                "1.misc": u"",
-                "4.feature": u"Stuff!",
-                "2.feature": u"Foo added.",
-                "72.feature": u"Foo added.",
-                "99.feature": u"Foo! " * 100
+                ("142", "misc"): u"",
+                ("1", "misc"): u"",
+                ("4", "feature"): u"Stuff!",
+                ("2", "feature"): u"Foo added.",
+                ("72", "feature"): u"Foo added.",
+                ("99", "feature"): u"Foo! " * 100
             }),
             ("Names", {}),
             ("Web", {
-                "3.bugfix": u"Web fixed.",
+                ("3", "bugfix"): u"Web fixed.",
             }),
         ])
 


### PR DESCRIPTION
This still needs tests, but it fixes #99 and ameliorates #101 well enough to
let me generate some actual release notes. It also adds some better
error checking. (Each commit is self-contained.)

As noted in #101, it probably would be better if towncrier had a
configuration option specifying what filename extension to use,
instead of blindly accepting all extensions. That would have been
cleverer of me. I think all these changes are probably still useful
in their own right though.