### PR TITLE
make fragment file removal work with extensions 

### DIFF
--- a/src/towncrier/_git.py
+++ b/src/towncrier/_git.py
@@ -59,7 +59,7 @@ def find_file_path(section_dir, category_name, ticket):
         if os.path.exists(path):
             return path
 
-    raise FileNotFoundError(
+    raise Exception(
         "can't find the file for fragment %s at %s - "
         "use no extension or one of the accepted (%s)" % (
             namestub, section_dir, accepted_extensions[1:]))

--- a/src/towncrier/_git.py
+++ b/src/towncrier/_git.py
@@ -24,10 +24,8 @@ def remove_files(base_dir, fragment_directory, sections, fragments,
             for tickets in category_items.values():
 
                 for ticket in tickets:
-
-                    filename = str(ticket) + "." + category_name
-                    to_remove.append(os.path.join(
-                        section_dir, filename))
+                    to_remove.append(find_file_path(
+                        section_dir, category_name, ticket))
 
     if not to_remove:
         return
@@ -48,3 +46,20 @@ def remove_files(base_dir, fragment_directory, sections, fragments,
 def stage_newsfile(directory, filename):
 
     call(["git", "add", os.path.join(directory, filename)])
+
+
+def find_file_path(section_dir, category_name, ticket):
+    accepted_extensions = ['', '.rst', '.txt']
+    namestub = "%s.%s" % (ticket, category_name)
+    for ext in accepted_extensions:
+        filename = namestub + ext
+
+        path = os.path.join(section_dir, filename)
+
+        if os.path.exists(path):
+            return path
+
+    raise FileNotFoundError(
+        "can't find the file for fragment %s at %s - "
+        "use no extension or one of the accepted (%s)" % (
+            namestub, section_dir, accepted_extensions[1:]))


### PR DESCRIPTION
fixes #99 

When generating the list of files to be removed it will be checked if the generated path exists for a collection of accepted extensions. To keep this change simple it is hardcoded to <no extension>, .rst and .txt - this could be made configurable in the future.

