### PR TITLE
make project name configurable from cli

### DIFF
--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -35,11 +35,23 @@ def _get_date():
 @click.option('--date', 'project_date', default=None)
 @click.option('--yes', 'answer_yes', default=False, flag_value=True,
               help="Do not ask for confirmation to remove news fragments.")
-def _main(draft, directory, project_name, project_version, project_date, answer_yes):
-    return __main(draft, directory, project_name, project_version, project_date, answer_yes)
+def _main(
+    draft, directory,
+    project_name, project_version, project_date,
+    answer_yes
+):
+    return __main(
+        draft, directory,
+        project_name, project_version, project_date,
+        answer_yes
+    )
 
 
-def __main(draft, directory, project_name, project_version, project_date, answer_yes):
+def __main(
+    draft, directory,
+    project_name, project_version, project_date,
+    answer_yes
+):
     """
     The main entry point.
     """

--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -30,15 +30,16 @@ def _get_date():
               help=("Render the news fragments, don't write to files, "
                     "don't check versions."))
 @click.option('--dir', 'directory', default='.')
+@click.option('--name', 'project_name', default=None)
 @click.option('--version', 'project_version', default=None)
 @click.option('--date', 'project_date', default=None)
 @click.option('--yes', 'answer_yes', default=False, flag_value=True,
               help="Do not ask for confirmation to remove news fragments.")
-def _main(draft, directory, project_version, project_date, answer_yes):
-    return __main(draft, directory, project_version, project_date, answer_yes)
+def _main(draft, directory, project_name, project_version, project_date, answer_yes):
+    return __main(draft, directory, project_name, project_version, project_date, answer_yes)
 
 
-def __main(draft, directory, project_version, project_date, answer_yes):
+def __main(draft, directory, project_name, project_version, project_date, answer_yes):
     """
     The main entry point.
     """
@@ -78,14 +79,15 @@ def __main(draft, directory, project_version, project_date, answer_yes):
         template, config['issue_format'], fragments, definitions,
         config['underlines'][1:])
 
-    if not project_version:
+    if project_version is None:
         project_version = get_version(
             os.path.abspath(os.path.join(directory, config['package_dir'])),
             config['package'])
 
-    project_name = get_project_name(
-        os.path.abspath(os.path.join(directory, config['package_dir'])),
-        config['package'])
+    if project_name is None:
+        project_name = get_project_name(
+            os.path.abspath(os.path.join(directory, config['package_dir'])),
+            config['package'])
 
     if project_date is None:
         project_date = _get_date()

--- a/src/towncrier/test/test_cli.py
+++ b/src/towncrier/test/test_cli.py
@@ -265,10 +265,22 @@ class TestCli(TestCase):
         self.assertEqual(0, result.exit_code)
         self.assertEqual(
             result.output,
-            u'Loading template...\nFinding news fragments...\nRendering news '
-            u'fragments...\nDraft only -- nothing has been written.\nWhat is '
-            u'seen below is what would be written.\n\nFooBarBaz 7.8.9 (01-01-2001)'
-            u'\n============================\n'
-            u'\n\nFeatures\n--------\n\n- Adds levitation (#123)\n'
-            u'- Extends levitation (#124)\n\n'
+            dedent("""
+            Loading template...
+            Finding news fragments...
+            Rendering news fragments...
+            Draft only -- nothing has been written.
+            What is seen below is what would be written.
+
+            FooBarBaz 7.8.9 (01-01-2001)
+            ============================
+
+
+            Features
+            --------
+
+            - Adds levitation (#123)
+            - Extends levitation (#124)
+
+            """).lstrip()
         )


### PR DESCRIPTION
I found that:
> It is usable by projects written in other languages, provided you give it the version of the project when invoking it.

Was not the case, as towncrier wanted to load a Python package in order to get the project name.

I've added another cli option to ignore that behaviour, in the same way as the version does. It now works in non-python projects 🌐