### PR TITLE
Made `package` optional.

### DIFF
--- a/src/towncrier/__init__.py
+++ b/src/towncrier/__init__.py
@@ -98,9 +98,15 @@ def __main(
             config['package'])
 
     if project_name is None:
-        project_name = get_project_name(
-            os.path.abspath(os.path.join(directory, config['package_dir'])),
-            config['package'])
+        package = config.get('package')
+        if package:
+            project_name = get_project_name(
+                os.path.abspath(
+                    os.path.join(directory, config['package_dir'])),
+                package)
+        else:
+            # Can't determine a project_name, but maybe it is not needed.
+            project_name = ''
 
     if project_date is None:
         project_date = _get_date()

--- a/src/towncrier/_settings.py
+++ b/src/towncrier/_settings.py
@@ -33,10 +33,6 @@ def load_config(from_dir):
 
     config = config['tool']['towncrier']
 
-    if 'package' not in config:
-        raise ValueError(
-            "The [tool.towncrier] section has no required 'package' key.")
-
     sections = OrderedDict()
     types = OrderedDict()
 
@@ -54,7 +50,7 @@ def load_config(from_dir):
         types = _default_types
 
     return {
-        'package': config.get('package'),
+        'package': config.get('package', ''),
         'package_dir': config.get('package_dir', '.'),
         'filename': config.get('filename', 'NEWS.rst'),
         'directory': config.get('directory'),

--- a/src/towncrier/newsfragments/111.feature
+++ b/src/towncrier/newsfragments/111.feature
@@ -1,0 +1,5 @@
+Made ``package`` optional.
+When the version is passed on the command line,
+and the ``title_format`` does not use the package name,
+and it is not used for the path to the news fragments,
+then no package name is needed, so we should not enforce it.


### PR DESCRIPTION
When the version is passed on the command line, and the `title_format` does not use the package name, and it is not used for the path to the news fragments, then no package name is needed, so we should not enforce it.

Closes issue #111.