### PR TITLE
Allow for multiple fragments with the same ticket and type

### DIFF
--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -69,7 +69,7 @@ def find_fragments(base_directory, sections, fragment_directory, definitions):
             full_filename = os.path.join(section_dir, basename)
             fragment_filenames.append(full_filename)
             with open(full_filename, "rb") as f:
-                data = f.read().decode('utf8', 'replace')
+                data = f.read().decode("utf8", "replace")
 
             if (ticket, category, counter) in file_content:
                 raise ValueError(

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -66,10 +66,21 @@ def find_fragments(base_directory, sections, fragment_directory, definitions):
         for basename in files:
             parts = basename.split(u".")
 
+            counter = 0
             if len(parts) == 1:
                 continue
             else:
                 ticket, category = parts[:2]
+
+            # If there is a number after the category then use it as a counter,
+            # otherwise ignore it.
+            # This means 1.feature.1 and 1.feature do not conflict but
+            # 1.feature.rst and 1.feature do.
+            if len(parts) > 2:
+                try:
+                    counter = int(parts[2])
+                except ValueError:
+                    pass
 
             if category not in definitions:
                 continue
@@ -78,12 +89,13 @@ def find_fragments(base_directory, sections, fragment_directory, definitions):
             fragment_filenames.append(full_filename)
             with open(full_filename, "rb") as f:
                 data = f.read().decode('utf8', 'replace')
-            if (ticket, category) in file_content:
+
+            if (ticket, category, counter) in file_content:
                 raise ValueError(
                     "multiple files for {}.{} in {}"
                     .format(ticket, category, section_dir)
                 )
-            file_content[ticket, category] = data
+            file_content[ticket, category, counter] = data
 
         content[key] = file_content
 
@@ -100,7 +112,7 @@ def split_fragments(fragments, definitions):
     for section_name, section_fragments in fragments.items():
         section = {}
 
-        for (ticket, category), content in section_fragments.items():
+        for (ticket, category, counter), content in section_fragments.items():
 
             content = normalise(content)
 

--- a/src/towncrier/_builder.py
+++ b/src/towncrier/_builder.py
@@ -119,7 +119,7 @@ def split_fragments(fragments, definitions):
             if definitions[category]["showcontent"] is False:
                 content = u""
 
-            texts = section.get(category, {})
+            texts = section.get(category, OrderedDict())
 
             if texts.get(content):
                 texts[content] = sorted(texts[content] + [ticket])

--- a/src/towncrier/newsfragments/119.feature
+++ b/src/towncrier/newsfragments/119.feature
@@ -1,0 +1,3 @@
+Add support for multiple fragements per issue/type pair. This extends the
+naming pattern of the fragments to `issuenumber.type(.counter)` where counter
+is an optional integer.

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -29,15 +29,15 @@ class FormatterTests(TestCase):
 
         fragments = {
             "": {
-                ("1", "misc"): u"",
-                ("baz", "misc"): u"",
-                ("2", "feature"): u"Foo added.",
-                ("5", "feature"): u"Foo added.    \n",
-                ("6", "bugfix"): u"Foo added.",
+                ("1", "misc", 0): u"",
+                ("baz", "misc", 0): u"",
+                ("2", "feature", 0): u"Foo added.",
+                ("5", "feature", 0): u"Foo added.    \n",
+                ("6", "bugfix", 0): u"Foo added.",
             },
             "Web": {
-                ("3", "bugfix"): u"Web fixed.    ",
-                ("4", "feature"): u"Foo added."
+                ("3", "bugfix", 0): u"Web fixed.    ",
+                ("4", "feature", 0): u"Foo added."
             }
         }
 
@@ -83,19 +83,19 @@ class FormatterTests(TestCase):
             ("", {
                 # asciibetical sorting will do 1, 142, 9
                 # we want 1, 9, 142 instead
-                ("142", "misc"): u"",
-                ("1", "misc"): u"",
-                ("9", "misc"): u"",
-                ("bar", "misc"): u"",
-                ("4", "feature"): u"Stuff!",
-                ("2", "feature"): u"Foo added.",
-                ("72", "feature"): u"Foo added.",
-                ("9", "feature"): u"Foo added.",
-                ("baz", "feature"): u"Fun!",
+                ("142", "misc", 0): u"",
+                ("1", "misc", 0): u"",
+                ("9", "misc", 0): u"",
+                ("bar", "misc", 0): u"",
+                ("4", "feature", 0): u"Stuff!",
+                ("2", "feature", 0): u"Foo added.",
+                ("72", "feature", 0): u"Foo added.",
+                ("9", "feature", 0): u"Foo added.",
+                ("baz", "feature", 0): u"Fun!",
             }),
             ("Names", {}),
             ("Web", {
-                ("3", "bugfix"): u"Web fixed.",
+                ("3", "bugfix", 0): u"Web fixed.",
             }),
         ])
 
@@ -190,10 +190,10 @@ Bugfixes
             "": {
                 # asciibetical sorting will do 1, 142, 9
                 # we want 1, 9, 142 instead
-                ("142", "misc"): u"",
-                ("1", "misc"): u"",
-                ("9", "misc"): u"",
-                ("bar", "misc"): u"",
+                ("142", "misc", 0): u"",
+                ("1", "misc", 0): u"",
+                ("9", "misc", 0): u"",
+                ("bar", "misc", 0): u"",
             }
         }
 
@@ -226,12 +226,12 @@ Misc
 
         fragments = {
             "": {
-                ("1", "feature"): u"""
+                ("1", "feature", 0): u"""
                 asdf asdf asdf asdf looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong newsfragment.
                 """,  # NOQA
-                ("2", "feature"): u"https://google.com/q=?" + u"-" * 100,
-                ("3", "feature"): u"a " * 80,
-                ("4", "feature"): u"""
+                ("2", "feature", 0): u"https://google.com/q=?" + u"-" * 100,
+                ("3", "feature", 0): u"a " * 80,
+                ("4", "feature", 0): u"""
                 w
 
                 h

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -25,8 +25,8 @@ class FormatterTests(TestCase):
             },
             "Web": {
                 ("3", "bugfix", 0): u"Web fixed.    ",
-                ("4", "feature", 0): u"Foo added."
-            }
+                ("4", "feature", 0): u"Foo added.",
+            },
         }
 
         expected_output = {
@@ -58,33 +58,39 @@ class FormatterTests(TestCase):
         Basic functionality -- getting a bunch of news fragments and formatting
         them into a rST file -- works.
         """
-        fragments = OrderedDict([
-            ("", {
-                # asciibetical sorting will do 1, 142, 9
-                # we want 1, 9, 142 instead
-                ("142", "misc", 0): u"",
-                ("1", "misc", 0): u"",
-                ("9", "misc", 0): u"",
-                ("bar", "misc", 0): u"",
-                ("4", "feature", 0): u"Stuff!",
-                ("2", "feature", 0): u"Foo added.",
-                ("72", "feature", 0): u"Foo added.",
-                ("9", "feature", 0): u"Foo added.",
-                ("baz", "feature", 0): u"Fun!",
-            }),
-            ("Names", {}),
-            ("Web", {
-                ("3", "bugfix", 0): u"Web fixed.",
-            }),
-        ])
+        fragments = OrderedDict(
+            [
+                (
+                    "",
+                    {
+                        # asciibetical sorting will do 1, 142, 9
+                        # we want 1, 9, 142 instead
+                        ("142", "misc", 0): u"",
+                        ("1", "misc", 0): u"",
+                        ("9", "misc", 0): u"",
+                        ("bar", "misc", 0): u"",
+                        ("4", "feature", 0): u"Stuff!",
+                        ("2", "feature", 0): u"Foo added.",
+                        ("72", "feature", 0): u"Foo added.",
+                        ("9", "feature", 0): u"Foo added.",
+                        ("baz", "feature", 0): u"Fun!",
+                    },
+                ),
+                ("Names", {}),
+                ("Web", {("3", "bugfix", 0): u"Web fixed."}),
+            ]
+        )
 
-        definitions = OrderedDict([
-            ("feature", {"name": "Features", "showcontent": True}),
-            ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-            ("misc", {"name": "Misc", "showcontent": False}),
-        ])
+        definitions = OrderedDict(
+            [
+                ("feature", {"name": "Features", "showcontent": True}),
+                ("bugfix", {"name": "Bugfixes", "showcontent": True}),
+                ("misc", {"name": "Misc", "showcontent": False}),
+            ]
+        )
 
-        expected_output = (u"""
+        expected_output = (
+            u"""
 Features
 --------
 
@@ -211,12 +217,16 @@ Misc
 
         fragments = {
             "": {
-                ("1", "feature", 0): u"""
+                (
+                    "1",
+                    "feature",
+                    0,
+                ): u"""
                 asdf asdf asdf asdf looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong newsfragment.
                 """,  # NOQA
                 ("2", "feature", 0): u"https://google.com/q=?" + u"-" * 100,
                 ("3", "feature", 0): u"a " * 80,
-            },
+            }
         }
 
         definitions = OrderedDict(

--- a/src/towncrier/test/test_format.py
+++ b/src/towncrier/test/test_format.py
@@ -271,11 +271,12 @@ Features
                 (
                     "1",
                     "feature",
+                    0
                 ): u"""
                 asdf asdf asdf asdf looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong newsfragment.
                 """,  # NOQA
-                ("2", "feature"): u"https://google.com/q=?" + u"-" * 100,
-                ("3", "feature"): u"a " * 80,
+                ("2", "feature", 0): u"https://google.com/q=?" + u"-" * 100,
+                ("3", "feature", 0): u"a " * 80,
             }
         }
 

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -15,26 +15,33 @@ from .._writer import append_to_newsfile
 class WritingTests(TestCase):
     def test_append_at_top(self):
 
-        fragments = OrderedDict([
-            ("", OrderedDict([
-                (("142", "misc", 0), u""),
-                (("1", "misc", 0), u""),
-                (("4", "feature", 0), u"Stuff!"),
-                (("4", "feature", 1), u"Second Stuff!"),
-                (("2", "feature", 0), u"Foo added."),
-                (("72", "feature", 0), u"Foo added."),
-            ])),
-            ("Names", {}),
-            ("Web", {
-                ("3", "bugfix", 0): u"Web fixed.",
-            }),
-        ])
+        fragments = OrderedDict(
+            [
+                (
+                    "",
+                    OrderedDict(
+                        [
+                            (("142", "misc", 0), u""),
+                            (("1", "misc", 0), u""),
+                            (("4", "feature", 0), u"Stuff!"),
+                            (("4", "feature", 1), u"Second Stuff!"),
+                            (("2", "feature", 0), u"Foo added."),
+                            (("72", "feature", 0), u"Foo added."),
+                        ]
+                    ),
+                ),
+                ("Names", {}),
+                ("Web", {("3", "bugfix", 0): u"Web fixed."}),
+            ]
+        )
 
-        definitions = OrderedDict([
-            ("feature", {"name": "Features", "showcontent": True}),
-            ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-            ("misc", {"name": "Misc", "showcontent": False}),
-        ])
+        definitions = OrderedDict(
+            [
+                ("feature", {"name": "Features", "showcontent": True}),
+                ("bugfix", {"name": "Bugfixes", "showcontent": True}),
+                ("misc", {"name": "Misc", "showcontent": False}),
+            ]
+        )
 
         expected_output = """MyProject 1.0
 =============
@@ -103,26 +110,31 @@ Old text.
         If there is a comment with C{.. towncrier release notes start},
         towncrier will add the version notes after it.
         """
-        fragments = OrderedDict([
-            ("", {
-                ("142", "misc", 0): u"",
-                ("1", "misc", 0): u"",
-                ("4", "feature", 0): u"Stuff!",
-                ("2", "feature", 0): u"Foo added.",
-                ("72", "feature", 0): u"Foo added.",
-                ("99", "feature", 0): u"Foo! " * 100
-            }),
-            ("Names", {}),
-            ("Web", {
-                ("3", "bugfix", 0): u"Web fixed.",
-            }),
-        ])
+        fragments = OrderedDict(
+            [
+                (
+                    "",
+                    {
+                        ("142", "misc", 0): u"",
+                        ("1", "misc", 0): u"",
+                        ("4", "feature", 0): u"Stuff!",
+                        ("2", "feature", 0): u"Foo added.",
+                        ("72", "feature", 0): u"Foo added.",
+                        ("99", "feature", 0): u"Foo! " * 100,
+                    },
+                ),
+                ("Names", {}),
+                ("Web", {("3", "bugfix", 0): u"Web fixed."}),
+            ]
+        )
 
-        definitions = OrderedDict([
-            ("feature", {"name": "Features", "showcontent": True}),
-            ("bugfix", {"name": "Bugfixes", "showcontent": True}),
-            ("misc", {"name": "Misc", "showcontent": False}),
-        ])
+        definitions = OrderedDict(
+            [
+                ("feature", {"name": "Features", "showcontent": True}),
+                ("bugfix", {"name": "Bugfixes", "showcontent": True}),
+                ("misc", {"name": "Misc", "showcontent": False}),
+            ]
+        )
 
         expected_output = """Hello there! Here is some info.
 

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -17,14 +17,14 @@ class WritingTests(TestCase):
     def test_append_at_top(self):
 
         fragments = OrderedDict([
-            ("", {
-                ("142", "misc", 0): u"",
-                ("1", "misc", 0): u"",
-                ("4", "feature", 0): u"Stuff!",
-                ("4", "feature", 1): u"Second Stuff!",
-                ("2", "feature", 0): u"Foo added.",
-                ("72", "feature", 0): u"Foo added.",
-            }),
+            ("", OrderedDict([
+                (("142", "misc", 0), u""),
+                (("1", "misc", 0), u""),
+                (("4", "feature", 0), u"Stuff!"),
+                (("4", "feature", 1), u"Second Stuff!"),
+                (("2", "feature", 0), u"Foo added."),
+                (("72", "feature", 0), u"Foo added."),
+            ])),
             ("Names", {}),
             ("Web", {
                 ("3", "bugfix", 0): u"Web fixed.",

--- a/src/towncrier/test/test_write.py
+++ b/src/towncrier/test/test_write.py
@@ -18,15 +18,16 @@ class WritingTests(TestCase):
 
         fragments = OrderedDict([
             ("", {
-                ("142", "misc"): u"",
-                ("1", "misc"): u"",
-                ("4", "feature"): u"Stuff!",
-                ("2", "feature"): u"Foo added.",
-                ("72", "feature"): u"Foo added.",
+                ("142", "misc", 0): u"",
+                ("1", "misc", 0): u"",
+                ("4", "feature", 0): u"Stuff!",
+                ("4", "feature", 1): u"Second Stuff!",
+                ("2", "feature", 0): u"Foo added.",
+                ("72", "feature", 0): u"Foo added.",
             }),
             ("Names", {}),
             ("Web", {
-                ("3", "bugfix"): u"Web fixed.",
+                ("3", "bugfix", 0): u"Web fixed.",
             }),
         ])
 
@@ -44,6 +45,7 @@ Features
 
 - Foo added. (#2, #72)
 - Stuff! (#4)
+- Second Stuff! (#4)
 
 
 Misc
@@ -102,16 +104,16 @@ Old text.
         """
         fragments = OrderedDict([
             ("", {
-                ("142", "misc"): u"",
-                ("1", "misc"): u"",
-                ("4", "feature"): u"Stuff!",
-                ("2", "feature"): u"Foo added.",
-                ("72", "feature"): u"Foo added.",
-                ("99", "feature"): u"Foo! " * 100
+                ("142", "misc", 0): u"",
+                ("1", "misc", 0): u"",
+                ("4", "feature", 0): u"Stuff!",
+                ("2", "feature", 0): u"Foo added.",
+                ("72", "feature", 0): u"Foo added.",
+                ("99", "feature", 0): u"Foo! " * 100
             }),
             ("Names", {}),
             ("Web", {
-                ("3", "bugfix"): u"Web fixed.",
+                ("3", "bugfix", 0): u"Web fixed.",
             }),
         ])
 


### PR DESCRIPTION
This extends the fragment format to be `<issue>.<type>(.<counter>)` i.e have an optional `.counter` after the type, which needs to be an integer.