### PR TITLE
ENH: Allow no bullet point framgents and file templating

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,7 @@ Towncrier has the following global options, which can be specified in the toml f
     issue_format = "format string for {issue} (issue is the first part of fragment name)"
     underlines: "=-~"
     wrap = false  # Wrap text to 79 characters
+    all_bullets = true  # make all fragments bullet points
 ```
 If a single file is used, the content of this file are overwritten each time.
 

--- a/src/towncrier/_settings.py
+++ b/src/towncrier/_settings.py
@@ -79,6 +79,13 @@ def parse_toml(config):
             failing_option="single_file",
         )
 
+    all_bullets = config.get("all_bullets", True)
+    if not isinstance(all_bullets, bool):
+        raise ConfigError(
+            "`all_bullets` option must be boolean: false or true.",
+            failing_option="all_bullets",
+        )
+
     return {
         "package": config.get("package", ""),
         "package_dir": config.get("package_dir", "."),
@@ -93,4 +100,5 @@ def parse_toml(config):
         "issue_format": config.get("issue_format"),
         "underlines": config.get("underlines", _underlines),
         "wrap": wrap,
+        "all_bullets": all_bullets,
     }

--- a/src/towncrier/build.py
+++ b/src/towncrier/build.py
@@ -120,7 +120,7 @@ def __main(
     )
 
     click.echo("Rendering news fragments...", err=to_err)
-    fragments = split_fragments(fragments, definitions)
+    fragments = split_fragments(fragments, definitions, all_bullets=config["all_bullets"])
 
     if project_version is None:
         project_version = get_version(
@@ -158,6 +158,7 @@ def __main(
         config["wrap"],
         {"name": project_name, "version": project_version, "date": project_date},
         top_underline=config["underlines"][0],
+        all_bullets=config["all_bullets"],
     )
 
     if draft:

--- a/src/towncrier/newsfragments/158.feature
+++ b/src/towncrier/newsfragments/158.feature
@@ -1,0 +1,8 @@
+There is now the option for ``all_bullets = false`` in the configuration.
+Setting ``all_bullets`` to false means that news fragments have to include
+the bullet point if they should be rendered as enumerations, otherwise
+they are rendered directly (this means fragments can include a header.).
+It is necessary to set this option to avoid (incorrect) automatic indentation
+of multiline fragments that do not include bullet points.
+The ``template-single-file-no-bullets.rst`` file gives an example template
+using these options.

--- a/src/towncrier/templates/template-single-file-no-bullets.rst
+++ b/src/towncrier/templates/template-single-file-no-bullets.rst
@@ -1,0 +1,38 @@
+{% set title = "{} {} Release Notes".format(versiondata.name, versiondata.version) %}
+{{ "=" * title|length }}
+{{ title }}
+{{ "=" * title|length }}
+
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{ section }}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section] %}
+
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+{{ text }}
+{{ get_indent(text) }}({{values|join(', ') }})
+
+{% endfor %}
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
This adds a single file mode to allow creating a single file for
each release. It also allows to disable automatic indentation of
bullet point items, since not all projects necessarily use
bullet points for release notes. In single file mode, the output
file is a format string of the `name`, `version`, and `project_date`
and the file is fully replaced (`start_line` is not supported).

`name`, `version`, and `project_date` are now available in the main
template, allowing to render the title there. To make this useful,
the `title_format` should be set to `false`.

---

Will create a newsfragment soon. Is this something you would like? Basically, I would like to be able to create most of our current numpy style release notes automatically (for example: https://github.com/numpy/numpy/blob/master/doc/release/1.17.0-notes.rst).